### PR TITLE
fix: create all directories in path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn generate_translation_files() {
 
     println!("Creating directory: {:?}", &dest_path);
     let _ = fs::remove_dir_all(&dest_path);
-    fs::create_dir(&dest_path).expect("Could not create translations directory");
+    fs::create_dir_all(&dest_path).expect("Could not create translations directory");
 
     println!("cargo:rerun-if-changed={}", I18N_DIR);
     let existing_iter = fs::read_dir(I18N_DIR)


### PR DESCRIPTION
If the project has never been compiled before, there is no `target` directory. `fs::create_dir` can only create one directory at a time but is asked to create `target/locale/,` meaning it errs with the following error:
```rust
error: failed to run custom build command for `tundra v0.4.2 (/home/seqre/Projects/tundra)`

Caused by:
  process didn't exit successfully: `/home/seqre/.cargo/target/debug/build/tundra-4b2e5a9315328618/build-script-build` (exit status: 101)
  --- stdout
  Creating directory: "target/locale"

  --- stderr
  thread 'main' panicked at 'Could not create translations directory: Os { code: 2, kind: NotFound, message: "No such file or directory" }', build.rs:19:32
```
`fs::create_dir_all` can alleviate the issue as it recursively creates directories.